### PR TITLE
Fix geojson coordinate order

### DIFF
--- a/caltechdata_api/customize_schema.py
+++ b/caltechdata_api/customize_schema.py
@@ -290,7 +290,7 @@ def customize_schema_rdm(json_record):
             if "geoLocationPoint" in location:
                 lat = location["geoLocationPoint"]["pointLatitude"]
                 lon = location["geoLocationPoint"]["pointLongitude"]
-                new["geometry"] = {"type": "Point", "coordinates": [lat, lon]}
+                new["geometry"] = {"type": "Point", "coordinates": [lon, lat]}
             if "geoLocationBox" in location:
                 south = float(location["geoLocationBox"]["southBoundLatitude"])
                 north = float(location["geoLocationBox"]["northBoundLatitude"])
@@ -300,11 +300,11 @@ def customize_schema_rdm(json_record):
                     "type": "Polygon",
                     "coordinates": [
                         [
-                            [north, east],
-                            [north, west],
-                            [south, west],
-                            [south, east],
-                            [north, east],
+                            [east, north],
+                            [west, north],
+                            [west, south],
+                            [east, south],
+                            [east, north],
                         ]
                     ],
                 }


### PR DESCRIPTION
Do not merge until the upstream fix is merged into InvenioRDM and loaded into CaltechDATA. The current behavior is incorrect in terms of geojson, but because the InvenioRDM serializer is wrong it generates a correct result.