### PR TITLE
Add missing requirement s3fs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ name = meta["name"]
 REQUIRES_PYTHON = ">=3.6.0"
 
 # What packages are required for this module to be executed?
-REQUIRED = ["requests", "datacite>1.1.0", "tqdm>=4.62.3", "pyyaml"]
+REQUIRED = ["requests", "datacite>1.1.0", "tqdm>=4.62.3", "pyyaml", "s3fs"]
 
 # What packages are optional?
 EXTRAS = {


### PR DESCRIPTION
Currently, doing an `import caltechdata_api` will result in an error if the `s3fs` package is not installed in the user's environment. This PR adds s3fs as a dependency during installation.